### PR TITLE
Updated links from github to phoenixframework.org

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -2,9 +2,9 @@
 
 ####In the meantime, these links might help.
 
-- [Phoenix Readme on Channels](https://github.com/phoenixframework/phoenix#channels)
+- [Phoenix Readme on Channels](http://www.phoenixframework.org/v0.8.0/docs/channels#channels)
 - [Phoenix Readme on Topics](https://github.com/phoenixframework/phoenix#topics)
-- [Phoenix Readme on Holding State in Sockets](https://github.com/phoenixframework/phoenix#holding-state-in-socket-connections)
+- [Phoenix Readme on Holding State in Sockets](http://www.phoenixframework.org/v0.8.0/docs/channels#holding-state-in-socket-connections)
 
 ####Back of the Napkin Guess At Topics to Cover
 - channels


### PR DESCRIPTION
The Github link no longer has content relevant to the mentioned #links.