### PR TITLE
Fix links to phoenixframework.org

### DIFF
--- a/B_adding_pages.md
+++ b/B_adding_pages.md
@@ -102,7 +102,7 @@ defmodule HelloPhoenix.Router do
 end
 
 ```
-For now, we'll ignore the pipelines and the use of `scope` here and just focus on adding a route. (We cover these topics in the [Routing Guide](http://www.phoenixframework.org/v0.8.0/docs/routing), if you're curious.)
+For now, we'll ignore the pipelines and the use of `scope` here and just focus on adding a route. (We cover these topics in the [Routing Guide](http://www.phoenixframework.org/docs/routing), if you're curious.)
 
 Let's add a new route to the router that maps a `GET` request for `/hello` to the `index` action of a soon-to-be-created `HelloPhoenix.HelloController`.
 
@@ -138,7 +138,7 @@ defmodule HelloPhoenix.HelloController do
   end
 end
 ```
-We'll save a discussion of `use Phoenix.Controller` and `plug :action` for the [Controllers Guide](http://www.phoenixframework.org/v0.8.0/docs/controllers). For now, let's focus on the `index/2` action.
+We'll save a discussion of `use Phoenix.Controller` and `plug :action` for the [Controllers Guide](http://www.phoenixframework.org/docs/controllers). For now, let's focus on the `index/2` action.
 
 All controller actions take two arguments. The first is `conn`, a struct which holds a ton of data about the request. The second is `params`, which are the request parameters. Here, we are not using `params`, and we avoid compiler warnings by adding the leading `_`.
 

--- a/G_channels.md
+++ b/G_channels.md
@@ -1,12 +1,5 @@
 #This Guide is Under Construction
 
-####In the meantime, these links might help.
+####In the meantime, this link might help.
 
-- [Phoenix Readme on Channels](http://www.phoenixframework.org/v0.8.0/docs/channels#channels)
-- [Phoenix Readme on Topics](https://github.com/phoenixframework/phoenix#topics)
-- [Phoenix Readme on Holding State in Sockets](http://www.phoenixframework.org/v0.8.0/docs/channels#holding-state-in-socket-connections)
-
-####Back of the Napkin Guess At Topics to Cover
-- channels
-- sockets
-- topics
+- [www.phoenixframework.org on Channels](http://www.phoenixframework.org/docs/channels#channels)

--- a/X_mix-tasks.md
+++ b/X_mix-tasks.md
@@ -10,7 +10,7 @@ We have seen all of these at one point or another in the guides, but having all 
 
 #### `mix phoenix.new`
 
-This is how we tell Phoenix the framework to generate a new Phoenix application for us. We saw it early on in the [Up and Running Guide](http://www.phoenixframework.org/v0.8.0/docs/up-and-running)
+This is how we tell Phoenix the framework to generate a new Phoenix application for us. We saw it early on in the [Up and Running Guide](http://www.phoenixframework.org/docs/up-and-running)
 
 We need to pass this task a name for our application, and a path so Phoenix knows where to create it. Conventionally, we use all lower-case letters with underscores for the name (snake case). We can use either a relative or absolute path for the second argument. The only requirement is that the path must be outside of Phoenix itself.
 
@@ -81,7 +81,7 @@ $ mix phoenix.new task_tester /Users/lance/work/task_tester
 
 #### `mix phoenix.routes`
 
-This task has a single purpose, to show us all the routes defined for a given router. We saw it used extensively in the [Routing Guide](http://www.phoenixframework.org/v0.8.0/docs/routing).
+This task has a single purpose, to show us all the routes defined for a given router. We saw it used extensively in the [Routing Guide](http://www.phoenixframework.org/docs/routing).
 
 If we don't specify a router for this task, it will default to the router Phoenix generated for us.
 


### PR DESCRIPTION
Remove Phoenix version number for links to phoenixframework.org.