### PR TITLE
Fix `use` line in new HelloView

### DIFF
--- a/B_adding_pages.md
+++ b/B_adding_pages.md
@@ -160,7 +160,7 @@ In order to render any templates for our `HelloController`, we need a `HelloView
 
 ```elixir
 defmodule HelloPhoenix.HelloView do
-  use HelloPhoenix.View
+  use HelloPhoenix.Web, :view
 end
 ```
 


### PR DESCRIPTION
I submitted this as a suggestion against readme.io already, but @jeregrine on IRC suggested I do it here.

I got the new `use` line by looking at the generated views after getting a compilation error using the original way.