### PR TITLE
Fix nginx setup steps

### DIFF
--- a/L_advanced_deployment.md
+++ b/L_advanced_deployment.md
@@ -377,7 +377,7 @@ Note: These points hold true for Apache as well, but the steps to accomplish the
 
 ```console
 $ sudo touch /etc/nginx/sites-available/hello_phoenix
-$ sudo ln -s /etc/nginx/sites-available /etc/nginx/sites-enabled
+$ sudo ln -s /etc/nginx/sites-available/hello_phoenix /etc/nginx/sites-enabled
 $ sudo vi /etc/nginx/sites-available/hello_phoenix
 ```
 


### PR DESCRIPTION
The original line symlinked whole `sites-available` directory, which results in nginx giving an error:

```
"/etc/nginx/sites-enabled/sites-available" failed (21: Is a directory)
```