### PR TITLE
refurbish channel guide for v0.10.0

### DIFF
--- a/G_channels.md
+++ b/G_channels.md
@@ -1,4 +1,4 @@
-Channels are a really exciting and powerful part of Phoenix, one that allows us to easily add soft-realtime features to our applications. Channels are based on a simple idea - sending and receiving messages. Senders broadcast messages about topics. Receivers subscribe to topics so that they can receive those messages. Senders and receivers can switch roles on the same topic at any time.
+Channels are a really exciting and powerful part of Phoenix, one that allows us to easily add soft-realtime features to our applications. Channels are based on a simple idea - sending and receiving messages. Senders broadcast messages about topics. Receivers subscribe to topics so that they can get those messages. Senders and receivers can switch roles on the same topic at any time.
 
 Since Elixir is based on message passing, you may wonder why we need this extra mechanism to send and receive messages. With Channels, neither senders nor receivers have to be Elixir processes. They can be anything that we can teach to communicate over a Channel - a JavaScript client, an iOS app, another Phoenix application, our watch. Also, messages broadcast over a Channel may have many receivers. Elixir processes communicate one to one.
 
@@ -24,9 +24,11 @@ Each Channel will implement one or more clauses of each of these four callback f
 
 - PubSub
 
-The `Phoenix.PubSub` module contains functions which are the nuts and bolts of organizing Channel communication - subscribing to topics, unsubscribing from topics, and broadcasting messages on a topic.
+The Phoenix PubSub layer consists of the `Phoenix.PubSub` module and a variety of modules for different adapters and their Genservers. These modules contain functions which are the nuts and bolts of organizing Channel communication - subscribing to topics, unsubscribing from topics, and broadcasting messages on a topic.
 
-It is worth noting that this module is intended for Phoenix's internal use. Channels use it under the hood to do much of their work. As end users, we shouldn't have any need to use PubSub directly.
+We can also define our own PubSub adapters if we need to. Please see the [Phoenix.PubSub docs](http://hexdocs.pm/phoenix/) for more information.
+
+It is worth noting that these modules are intended for Phoenix's internal use. Channels use them under the hood to do much of their work. As end users, we shouldn't have any need to use them directly in our applications.
 
 - Sockets
 
@@ -65,31 +67,55 @@ The default transport mechanism is via WebSockets which will fall back to LongPo
 Phoenix currently ships with it's own JavaScript client. There is a Swift client under construction, and an Android client would be great if anyone finds that project exciting and would like to write one.
 
 #### A Quick Test Run
-Before we go in-depth into Channels, let's do a quick test to get a feeling for how this works. We'll broadcast a simple message to ourselves in iex on the topic `"rooms:demo"`. Let's shut down our application if it is already running by hitting `ctrl-c` twice in the iex session. Then let's run `$ iex -S mix` at the root of our application.
+Before we go in-depth into Channels, let's do a quick test to get a feeling for how this works. We'll broadcast a simple message to ourselves in iex on the topic `"rooms:demo"`. Let's shut down our application if it is already running by hitting `ctrl-c` twice in the iex session. Then let's run `$ iex -S mix phoenix.server` at the root of our application.
 
 Normally, we would not work with the `Phoenix.PubSub` module directly. Since we won't be handling external requests, and since we want to keep this as simple as possible, we will be using it here.
 
-Before we begin, let's see if we have any subscribers for the topic we'll use for demo purposes.
+```console
+$ iex -S mix phoenix.server
+Erlang/OTP 17 [erts-6.0] [source-07b8f44] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
+
+[info] Running HelloPhoenix.Endpoint with Cowboy on port 4000 (http)
+Interactive Elixir (1.0.3) - press Ctrl+C to exit (type h() ENTER for help)
+iex(1)> 24 Mar 09:21:40 - info: compiled 3 files into 2 files in 559ms
+```
+
+Great, now we'll need to start our local PubSub gen_server. While we're at it, we can bind a few variables that will make things a little easier for ourselves.
 
 ```console
-iex(1)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "rooms:demo")
-#HashSet<[]>
+iex(2)> adapter = Phoenix.PubSub.PG2
+Phoenix.PubSub.PG2
+
+iex(3)> local = Phoenix.PubSub.PG2.Local
+Phoenix.PubSub.PG2.Local
+
+iex(4)> {:ok, pid} = adapter.start_link(adapter, [])
+{:ok, #PID<0.274.0>}
+```
+
+Now that we're up and running, let's see if we have any subscribers for the topic we'll use for demo purposes.
+
+```console
+iex(1)> Phoenix.PubSub.Local.subscribers(local, "rooms:demo")
+[]
 ```
 Nobody there yet so let's subscribe ourselves and check again.
 
 ```console
-iex(2)> Phoenix.PubSub.subscribe(HelloPhoenix.PubSub, self, "rooms:demo")
+iex(2)> Phoenix.PubSub.subscribe(adapter, self, "rooms:demo")
 :ok
-iex(3)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "rooms:demo")
-#HashSet<[#PID<0.144.0>]>
+
+iex(3)> Phoenix.PubSub.Local.subscribers(local, "rooms:demo")
+[#PID<0.144.0>]
 ```
 Great, now we will receive any messages broadcast to this topic.
 
 Let's check that by broadcasting a message to see if we receive it.
 
 ```console
-iex(4)> Phoenix.PubSub.broadcast(HelloPhoenix.PubSub, "rooms:demo", %{message: "It Works!"})
+iex(4)> Phoenix.PubSub.broadcast(adapter, "rooms:demo", %{message: "It Works!"})
 :ok
+
 iex(5)> Process.info(self)[:messages]
 %{message: "It Works!"}
 ```
@@ -98,16 +124,19 @@ Note that we check our own process info for messages.
 We can also unsubscribe ourselves from a topic.
 
 ```console
-iex(6)> Phoenix.PubSub.unsubscribe(HelloPhoenix.PubSub, self, "rooms:demo")
+iex(6)> Phoenix.PubSub.unsubscribe(adapter, self, "rooms:demo")
 :ok
-iex(7)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "rooms:demo")
-#HashSet<[]>
+
+iex(7)> Phoenix.PubSub.Local.subscribers(local, "rooms:demo")
+[]
 ```
-This is the simplest possible demonstration of sending messages about topics. Great, so let's dig a little deeper.
+This is the simplest possible demonstration of sending messages about topics.
 
-### Let's Build a Channel
+Now that we have this working, let's dig a little deeper.
 
-The first thing we are going to need is a route, so let's add a channel route to our `web/router.ex` file like this.
+### Building a Channel
+
+The first thing we are going to need is a route, so let's add a channel route to our `web/router.ex` file.
 
 ```elixir
 socket "/ws", HelloPhoenix do
@@ -138,21 +167,37 @@ defmodule HelloPhoenix.FoodChannel do
   end
 end
 ```
+
+For this whole section, let's quit out of any iex sessions we have running and begin with a fresh session. We'll also bind some handy variables and start our PubSub server as we did before.
+
+```console
+$ iex -S mix phoenix.server
+. . .
+iex(2)> adapter = Phoenix.PubSub.PG2
+Phoenix.PubSub.PG2
+
+iex(3)> local = Phoenix.PubSub.PG2.Local
+Phoenix.PubSub.PG2.Local
+
+iex(4)> {:ok, pid} = adapter.start_link(adapter, [])
+{:ok, #PID<0.274.0>}
+```
+
 Let's explore this a little bit in iex. Before we do anything, we should check to see if we have any subscribers on our "foods:all" topic.
 
 ```conole
-ex(1)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "foods:all")
-#HashSet<[]>
+ex(1)> Phoenix.PubSub.Local.subscribers(local, "foods:all")
+[]
 ```
 Ok, nobody has subscribed yet. What we're going to do is to dispatch a message to our `FoodChannel` which will be handled by the `join/3` function and authorize our socket.
 
-The first thing we need to do is create a socket. This one will work.
+The first thing we need to do is create a `socket` struct. This one will work.
 
 ```console
-iex(2)> socket = %Phoenix.Socket{pid: self, router: HelloPhoenix.Router, topic: "foods:all", assigns: [], transport: Phoenix.Transports.WebSocket, pubsub_server: HelloPhoenix.PubSub}
+iex(2)> socket = %Phoenix.Socket{pid: self, router: HelloPhoenix.Router, topic: "foods:all", assigns: [], transport: Phoenix.Transports.WebSocket, pubsub_server: local}
 
 %Phoenix.Socket{assigns: [], authorized: false, channel: nil,
-  pid: #PID<0.200.0>, pubsub_server: HelloPhoenix.PubSub,
+  pid: #PID<0.269.0>, pubsub_server: Phoenix.PubSub.PG2.Local,
   router: HelloPhoenix.Router, topic: "foods:all",
   transport: Phoenix.Transports.WebSocket}
 ```
@@ -167,23 +212,24 @@ iex(4)> {:ok, socket} = Phoenix.Channel.Transport.dispatch socket, "foods:all", 
 
 {:ok,
   %Phoenix.Socket{assigns: [], authorized: true,
-    channel: HelloPhoenix.FoodChannel, pid: #PID<0.200.0>,
-    pubsub_server: HelloPhoenix.PubSub, router: HelloPhoenix.Router,
+    channel: HelloPhoenix.FoodChannel, pid: #PID<0.269.0>,
+    pubsub_server: Phoenix.PubSub.PG2.Local, router: HelloPhoenix.Router,
     topic: "foods:all", transport: Phoenix.Transports.WebSocket}}
 ```
 Notice that from the response, we can tell that this socket is now authorized for the `"foods:all"` topic. This is the result of returning `{:ok, socket}` from the `join/3` function. We also took care to re-bind the socket so that if we need it again in subsequent steps, it will be authorized on this topic for this channel.
 
-The question is, did it really work? Were we subscribed to the topic? Let's find out using `subscribers/1`.
+The question is, did it really work? Were we subscribed to the topic? Let's find out using `subscribers/2`.
 
 ```console
-iex(5)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "foods:all")
-#HashSet<[#PID<0.200.0>]>
+iex(5)> Phoenix.PubSub.Local.subscribers(local, "foods:all")
+[#PID<0.269.0>]
+
 iex(6)> self
-#PID<0.200.0>
+#PID<0.269.0>
 ```
 Yes, we clearly are subscribed to the `"foods:all"` topic.
 
-Let's take a look at what happens when we try to join a topic that does not authorize us. We'll need an additional clause of the `join/3` function in our `FoodChannel`, like this.
+Let's take a look at what happens when we try to join a topic that does not authorize us. We'll need an additional clause of the `join/3` function in our `FoodChannel`.
 
 ```elixir
 defmodule HelloPhoenix.FoodChannel do
@@ -192,51 +238,67 @@ defmodule HelloPhoenix.FoodChannel do
   def join("foods:all", _message, socket) do
     {:ok, socket}
   end
-  def join("foods:" <> _priv_topic, _message, socket) do
+  def join("foods:" <> _priv_topic, _message, _socket) do
     :ignore
   end
 end
 ```
-This time, we hard-code the return value of `:ignore`, so no attempt to join this topic should ever succeed.
+
+This time, we hard-code the return value of `:ignore`, so no attempt to join this topic should ever succeed. We'll also need to recompile our `FoodChannel` module.
+
+```console
+iex(18)> r HelloPhoenix.FoodChannel
+web/channels/food_channel.ex:1: warning: redefining module HelloPhoenix.FoodChannel
+{:reloaded, HelloPhoenix.FoodChannel, [HelloPhoenix.FoodChannel]}
+```
 
 We'll use a new socket for this, one with the new topic we are matching on as well as the default value for `authorized`, which is false.
 
 ```console
-iex(1)> new_socket = %Phoenix.Socket{pid: self, router: HelloPhoenix.Router, topic: "foods:forbidden", assigns: [], transport: Phoenix.Transports.WebSocket, pubsub_server: HelloPhoenix.PubSub}
+iex(1)> new_socket = %Phoenix.Socket{pid: self, router: HelloPhoenix.Router, topic: "foods:forbidden", assigns: [], transport: Phoenix.Transports.WebSocket, pubsub_server: local}
 
 %Phoenix.Socket{assigns: [], authorized: false, channel: nil,
-  pid: #PID<0.144.0>, pubsub_server: HelloPhoenix.PubSub,
+  pid: #PID<0.269.0>, pubsub_server: Phoenix.PubSub.PG2.Local,
   router: HelloPhoenix.Router, topic: "foods:forbidden",
   transport: Phoenix.Transports.WebSocket}
 ```
 When we dispatch again on our `new_socket`, we see that we ignore the join attempt and throw away the unauthorized socket.
 
 ```console
-iex(3)> :ignore = Phoenix.Channel.Transport.dispatch new_socket, "foods:forbidden", "join", %{}
+iex(3)> :ignore = Phoenix.Channel.Transport.dispatch(new_socket, "foods:forbidden", "join", %{})
 ```
 Just to make sure, let's check the subscribers again.
 
 ```cosole
-iex(4)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "foods:forbidden")
-#HashSet<[]>
+iex(4)> Phoenix.PubSub.Local.subscribers(local, "foods:forbidden")
+[]
 ```
 
 #### Leaving a Channel Topic
 
 Once we can join topics on channels, the next step is being able to leave them. For this, we need the `leave/2` function defined in our `FoodChannel`. In a fresh iex session, let's join two topics on our `FoodChannel` using the steps above. For our example, let's use "foods:all" and "foods:delightful".
 
+Note: In order to make this work, we'll have to re-define the second clause of our `join/3` function to return `{:ok, socket}`.
+
+```elixir
+def join("foods:" <> _priv_topic, _message, _socket) do
+  {:ok, socket}
+end
+```
+
 Before we go further, let's make sure we really are subscribed to those topics.
 
 ```console
 iex(10)> self
-#PID<0.151.0>
+#PID<0.269.0>
 
-iex(11)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "foods:all")
-#HashSet<[#PID<0.151.0>]>
+iex(11)> Phoenix.PubSub.Local.subscribers(local, "foods:all")
+[#PID<0.269.0>]
 
-iex(12)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "foods:delightful")
-#HashSet<[#PID<0.151.0>]>
+iex(12)> Phoenix.PubSub.Local.subscribers(local, "foods:delightful")
+[#PID<0.269.0>]
 ```
+
 Great, now let's add our `leave/2` function. For our purposes, we have no restrictions on leaving a topic, so let's always return `{:ok, socket}`.
 
 ```elixir
@@ -244,32 +306,42 @@ def leave(_reason, socket) do
   {:ok, socket}
 end
 ```
+
+Again, we'll need to recompile our `FoodChannel` module.
+
+```console
+iex(18)> r HelloPhoenix.FoodChannel
+web/channels/food_channel.ex:1: warning: redefining module HelloPhoenix.FoodChannel
+{:reloaded, HelloPhoenix.FoodChannel, [HelloPhoenix.FoodChannel]}
+```
+
 Great, now let's call the `dispatch/4` function again using the "foods:all" topic and the "leave" event. Again, this request will make it's way from the router all the way to the `leave/2` function in our `FoodChannel`.
 
 ```console
-iex(22)> {:leave, socket} = Phoenix.Channel.Transport.dispatch socket, "foods:all", "leave", %{}
-
+iex(40)> {:leave, socket} = Phoenix.Channel.Transport.dispatch socket, "foods:all", "leave", %{}
 {:leave,
   %Phoenix.Socket{assigns: [], authorized: false,
-    channel: HelloPhoenix.FoodChannel, pid: #PID<0.144.0>,
-    pubsub_server: HelloPhoenix.PubSub, router: HelloPhoenix.Router,
+    channel: HelloPhoenix.FoodChannel, pid: #PID<0.269.0>,
+    pubsub_server: Phoenix.PubSub.PG2.Local, router: HelloPhoenix.Router,
     topic: "foods:all", transport: Phoenix.Transports.WebSocket}}
 ```
+
 Notice that the request processing didn't stop with the return of `leave/2`. The final tuple we get back is `{:leave, socket}` instead of `{:ok, socket}`. The socket also is no longer authorized for the "foods:all" topic for this channel.
 
 Did it really unsubscribe us? Let's see.
 
 ```console
-iex(23)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "foods:all")
-#HashSet<[]>
+iex(23)> Phoenix.PubSub.Local.subscribers(local, "foods:all")
+[]
 ```
+
 Indeed it did.
 
 And, of course, we are still subscribed to the "foods:delightful" topic.
 
 ```console
-iex(24)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "foods:delightful")
-#HashSet<[#PID<0.151.0>]>
+iex(24)> Phoenix.PubSub.Local.subscribers(local, "foods:delightful")
+[#PID<0.269.0>]
 ```
 
 #### Incoming Messages
@@ -293,8 +365,8 @@ Both `broadcast!/3` and `reply/3` return `{:ok, socket}`, so we don't need to ad
 Let's see this in action. First, let's make sure we have joined the `"foods:all`" topic on the `FoodChannel`.
 
 ```console
-iex(7)> Phoenix.PubSub.subscribers(HelloPhoenix.PubSub, "foods:all")
-#HashSet<[#PID<0.153.0>]>
+iex(7)> Phoenix.PubSub.Local.subscribers(local, "foods:all")
+[#PID<0.269.0>]
 ```
 If your pid isn't in the subscribers list, please follow the steps in "Joining a Channel Topic" above.
 
@@ -312,8 +384,8 @@ If the socket is not authorized for the topic, we can fix that with the `authori
 iex(9)> socket = Phoenix.Socket.authorize(socket, "foods:all")
 
 %Phoenix.Socket{assigns: [], authorized: true,
-  channel: HelloPhoenix.FoodChannel, pid: #PID<0.153.0>,
-  pubsub_server: HelloPhoenix.PubSub, router: HelloPhoenix.Router,
+  channel: HelloPhoenix.FoodChannel, pid: #PID<0.269.0>,
+  pubsub_server: Phoenix.PubSub.PG2.Local, router: HelloPhoenix.Router,
   topic: "foods:all", transport: Phoenix.Transports.WebSocket}
 ```
 Now that our socket is authorized, we can dispatch a message. This works exactly the same way that we have used it up to now, passing in a socket, topic, event, and message.
@@ -323,8 +395,8 @@ iex(10)> {:ok, socket} = Phoenix.Channel.Transport.dispatch socket, "foods:all",
 
 {:ok,
   %Phoenix.Socket{assigns: [], authorized: true,
-    channel: HelloPhoenix.FoodChannel, pid: #PID<0.153.0>,
-    pubsub_server: HelloPhoenix.PubSub, router: HelloPhoenix.Router,
+    channel: HelloPhoenix.FoodChannel, pid: #PID<0.269.0>,
+    pubsub_server: Phoenix.PubSub.PG2.Local, router: HelloPhoenix.Router,
     topic: "foods:all", transport: Phoenix.Transports.WebSocket}}
 ```
 Note: Again, the message must be a map. Any other type of value will throw an error.
@@ -337,6 +409,7 @@ iex(11)> Process.info(self)[:messages]
 [socket_broadcast: %Phoenix.Socket.Message{event: "new:msg",
 payload: %{say: "Success!"}, topic: "foods:all"}]
 ```
+
 And it worked.
 
 We can use pattern matching to offer more flexibility for the events that `handle_in/3` will respond to. As an experiment, try creating a new clause of `handle_in/3` like the one below and dispatch a message to `"foods:all"` with a `"new:burrito"` event.


### PR DESCRIPTION
- fixes the immediately broken instructions
- still missing broadcasting to external topics (via controllers and channels), which will be handled in another PR