### PR TITLE
Fix Elixir install information link

### DIFF
--- a/A_up_and_running.md
+++ b/A_up_and_running.md
@@ -1,6 +1,6 @@
 The aim of this first guide is to get a Phoenix application up and running as quickly as possible.
 
-Before we begin, we will need to install Elixir and Erlang. The Elixir site itself has the latest and most complete [installation information](http://elixir-lang.org/getting_started/1.html). Currently, Phoenix requires Elixir version 1.0.0 or greater which in turn requires Erlang version 17.0 or greater.
+Before we begin, we will need to install Elixir and Erlang. The Elixir site itself has the latest and most complete [installation information](http://elixir-lang.org/install.html). Currently, Phoenix requires Elixir version 1.0.0 or greater which in turn requires Erlang version 17.0 or greater.
 
 Let's get started.
 


### PR DESCRIPTION
The installation information link is currently pointing to the first page of the getting started instead of the installation page itself.