### PR TITLE
Improvements to ecto guide

### DIFF
--- a/H_ecto-models.md
+++ b/H_ecto-models.md
@@ -189,15 +189,15 @@ defmodule HelloPhoenix.User do
   use HelloPhoenix.Web, :model
 
   schema "users" do
-    field :first_name, :string
-    field :last_name, :string
+    field :name, :string
     field :email, :string
+    field :bio, :string
     field :number_of_pets, :integer
 
     timestamps
   end
 
-  @required_fields ~w(first_name last_name email number_of_pets)
+  @required_fields ~w(name email bio number_of_pets)
   @optional_fields ~w()
 
   @doc """
@@ -245,13 +245,13 @@ Then let's create a changeset from our model with an empty `User` struct, and an
 ```console
 iex(2)> changeset = User.changeset(%User{}, %{})
   %Ecto.Changeset{changes: %{},
-    errors: [first_name: "can't be blank", last_name: "can't be blank",
-    email: "can't be blank", number_of_pets: "can't be blank"], filters: %{},
+    errors: [name: "can't be blank", email: "can't be blank",
+    bio: "can't be blank", number_of_pets: "can't be blank"], filters: %{},
       model: %HelloPhoenix.User{__meta__: %Ecto.Schema.Metadata{source: "users",
-      state: :built}, email: nil, first_name: nil, id: nil, inserted_at: nil,
-      last_name: nil, number_of_pets: nil, updated_at: nil}, optional: [],
+      state: :built}, bio: nil, email: nil, id: nil, inserted_at: nil,
+      name: nil, number_of_pets: nil, updated_at: nil}, optional: [],
       params: %{}, repo: nil,
-        required: [:first_name, :last_name, :email, :number_of_pets], valid?: false,
+        required: [:name, :email, :bio, :number_of_pets], valid?: false,
         validations: []}
 ```
 
@@ -266,8 +266,8 @@ Since this one is not valid, we can ask it what the errors are.
 
 ```console
 iex(4)> changeset.errors
-[first_name: "can't be blank", last_name: "can't be blank",
-email: "can't be blank", number_of_pets: "can't be blank"]
+[name: "can't be blank", email: "can't be blank",
+bio: "can't be blank", number_of_pets: "can't be blank"]
 ```
 
 It gives us the same list of fields that can't be blank that we got from the front end of our application.
@@ -275,11 +275,11 @@ It gives us the same list of fields that can't be blank that we got from the fro
 Now let's test this by moving the `number_of_pets` field from `@required_fields` to `@optional_fields`.
 
 ```elixir
-@required_fields ~w(first_name last_name email)
+@required_fields ~w(name email bio)
 @optional_fields ~w(number_of_pets)
 ```
 
-Now either method of verification should tell us that only `first_name`, `last_name`, and `email` can't be blank.
+Now either method of verification should tell us that only `name`, `email`, and `bio` can't be blank.
 
 What happens if we pass a key/value pair that in neither `@required_fields` nor `@optional_fields`? Let's find out.
 
@@ -293,8 +293,8 @@ nil
 Lets create a `params` map with valid values plus an extra `random_key: "random value"`.
 
 ```console
-iex(2)> params = %{first_name: "Joe", last_name: "Example", email: "joe@example.com", number_of_pets: 5, random_key: "random value"}
-%{email: "joe@example.com", first_name: "Joe", last_name: "Example",
+iex(2)> params = %{name: "Joe Example", email: "joe@example.com", bio: "An example to all", number_of_pets: 5, random_key: "random value"}
+%{email: "joe@example.com", name: "Joe Example", bio: "An example to all",
 number_of_pets: 5, random_key: "random value"}
 ```
 
@@ -302,16 +302,16 @@ Then let's use our new `params` map to create a changeset.
 
 ```console
 iex(3)> changeset = User.changeset(%User{}, params)
-  %Ecto.Changeset{changes: %{email: "joe@example.com", first_name: "Joe",
-  last_name: "Example", number_of_pets: 5}, errors: [], filters: %{},
+  %Ecto.Changeset{changes: %{bio: "An example to all", email: "joe@example.com",
+  name: "Joe Example", number_of_pets: 5}, errors: [], filters: %{},
     model: %HelloPhoenix.User{__meta__: %Ecto.Schema.Metadata{source: "users",
-    state: :built}, email: nil, first_name: nil, id: nil, inserted_at: nil,
-    last_name: nil, number_of_pets: nil, updated_at: nil},
+    state: :built}, bio: nil, email: nil, id: nil, inserted_at: nil,
+    name: nil, number_of_pets: nil, updated_at: nil},
     optional: [:number_of_pets],
-    params: %{"email" => "joe@example.com", "first_name" => "Joe",
-    "last_name" => "Example", "number_of_pets" => 5,
+    params: %{"bio" => "An example to all", "email" => "joe@example.com",
+    "name" => "Joe Example", "number_of_pets" => 5,
     "random_key" => "random value"}, repo: nil,
-    required: [:first_name, :last_name, :email], valid?: true,
+    required: [:name, :email, :bio], valid?: true,
     validations: []}
 ```
 
@@ -326,7 +326,7 @@ We can also check the changeset's changes - the map we get after all of the tran
 
 ```console
 iex(9)> changeset.changes
-%{email: "joe@example.com", first_name: "Joe", last_name: "Example",
+%{bio: "An example to all", email: "joe@example.com", name: "Joe Example",
 number_of_pets: 5}
 ```
 
@@ -334,39 +334,39 @@ Notice that our `random_key` and `random_value` have been removed from our final
 
 We can validate more than just whether a field is required or not. Let's take a look at some finer grained validations.
 
-What if we had a requirement that all last names in our system must be at least two characters long? We can do this easily by adding another transformation to the pipeline in our changeset which validates the length of the `last_name` field.
+What if we had a requirement that all biographies in our system must be at least two characters long? We can do this easily by adding another transformation to the pipeline in our changeset which validates the length of the `bio` field.
 
 ```elixir
 def changeset(model, params \\ nil) do
   model
   |> cast(params, @required_fields, @optional_fields)
-  |> validate_length(:last_name, min: 2)
+  |> validate_length(:bio, min: 2)
 end
 ```
 
-Now if we try to add add a new user through the front end of the application with a last name of "A", we should see this error message at the top of the page.
+Now if we try to add add a new user through the front end of the application with a bio of "A", we should see this error message at the top of the page.
 
 ```text
 Oops, something went wrong! Please check the errors below:
-Last name should be at least 2 characters
+Bio should be at least 2 characters
 ```
 
-If we also have a requirement for the maximum length that a last name can have, we can simply add another validation.
+If we also have a requirement for the maximum length that a bio can have, we can simply add another validation.
 
 ```elixir
 def changeset(model, params \\ nil) do
   model
   |> cast(params, @required_fields, @optional_fields)
-  |> validate_length(:last_name, min: 2)
-  |> validate_length(:last_name, max: 25)
+  |> validate_length(:bio, min: 2)
+  |> validate_length(:bio, max: 140)
 end
 ```
 
-Now if we try to add a new user with a twenty-six character last name, we would see this error.
+Now if we try to add a new user with a 141 character bio, we would see this error.
 
 ```text
 Oops, something went wrong! Please check the errors below:
-Last name should be at most 25 characters
+Bio should be at most 140 characters
 ```
 
 Let's say we want to perform at least some rudimentary format validation on the `email` field. All we want to check for is the presence of the "@". The `validate_format/3` function is just what we need.
@@ -375,8 +375,8 @@ Let's say we want to perform at least some rudimentary format validation on the 
 def changeset(model, params \\ nil) do
   model
   |> cast(params, @required_fields, @optional_fields)
-  |> validate_length(:last_name, min: 2)
-  |> validate_length(:last_name, max: 25)
+  |> validate_length(:bio, min: 2)
+  |> validate_length(:bio, max: 140)
   |> validate_format(:email, ~r/@/)
 end
 ```

--- a/H_ecto-models.md
+++ b/H_ecto-models.md
@@ -1,4 +1,4 @@
-Most web applications today need some form of data storage. In the Elixir ecosystem, we have Ecto to enable this. Ecto currently has adapters for the PostgreSQL and MySQL relational databases. More adapters will likely follow in the future. Newly generated Phoenix applications integrate both Ecto and the Posgrex adapter by default.
+Most web applications today need some form of data storage. In the Elixir ecosystem, we have Ecto to enable this. Ecto currently has adapters for the PostgreSQL and MySQL relational databases. More adapters will likely follow in the future. Newly generated Phoenix applications integrate both Ecto and the Postgrex adapter by default.
 
 This guide assumes that we have generated our new application with Ecto. If we're using an older Phoenix app, or we used the `--no-ecto` option to generate our application, all is not lost. Please follow the instructions in the "Integrating Ecto" section below.
 
@@ -214,7 +214,7 @@ end
 
 ```
 
-The schema block at the top of the model should be pretty self-explanitory. We'll take a look at changesets next.
+The schema block at the top of the model should be pretty self-explanatory. We'll take a look at changesets next.
 
 ####Changesets and Validations
 

--- a/H_ecto-models.md
+++ b/H_ecto-models.md
@@ -159,7 +159,7 @@ defmodule HelloPhoenix.Repo do
 end
 ```
 
-Our repo clearly has two main tasks - to bring in all the common query functions from `Ecto.Repo` and to set the `otp_app` name equal to our application name.
+Our repo has two main tasks - to bring in all the common query functions from `Ecto.Repo` and to set the `otp_app` name equal to our application name.
 
 When `phoenix.new` generated our application, it also generated some basic configuration as well. Let's look at `config/dev.exs`.
 
@@ -229,7 +229,7 @@ def changeset(model, params \\ nil) do
 end
 ```
 
-At this point, we only have one transformation in our pipeline. This `cast/4` function's main job is to separate required fields from optional ones. We define the fields for each category in the module attributes `@required_fields` and `@optional_fields`. By default, obviously, all of the fields are required.
+At this point, we only have one transformation in our pipeline. This `cast/4` function's main job is to separate required fields from optional ones. We define the fields for each category in the module attributes `@required_fields` and `@optional_fields`. By default all of the fields are required.
 
 Let's take a look at two ways to validate that this is the case. The first and easiest way is to simply start our application by running the `mix phoenix.server` task at the root of our project. Then we can go to the [new users page](http://localhost:4000/users/new) and click the "submit" button without filling in any fields. We should get an error telling us that something went wrong and enumerating all the fields which can't be blank. That should be all the fields in our schema at this point.
 
@@ -262,7 +262,7 @@ iex(3)> changeset.valid?
 false
 ```
 
-Since this one is clearly not valid, we can ask it what the errors are.
+Since this one is not valid, we can ask it what the errors are.
 
 ```console
 iex(4)> changeset.errors
@@ -458,7 +458,7 @@ If the changeset is invalid, we re-render `new.html` with the changeset to displ
 
 In the `show` action, we use the `Repo.get/2` built-in function to fetch the user record identified by the id we get from the request parameters. We don't generate a changeset here because we assume that the data has passed through a changeset on the way in to the database, and therefore is valid when we retrieve it here.
 
-Essentially, this is the singular version of `index` above.
+This is the singular version of `index` above.
 
 ```elixir
 def show(conn, %{"id" => id}) do
@@ -568,7 +568,7 @@ worker(HelloPhoenix.Repo, [])
 
 Note: Please see the "Repo" section above for information on what the repo does.
 
-This task clearly creates a directory for our repo as well as the repo itself.
+This task creates a directory for our repo as well as the repo itself.
 
 ```elixir
 defmodule HelloPhoenix.Repo do


### PR DESCRIPTION
This PR contains a couple of typo fixes and some larger changes to provide more culturally accepting examples.

### Remove "clearly", "obviously", "essentially"
Using language like "clearly", "obviously", and
"basically" is a common habit and is not intended
to be negative, but it can be offputting when
found in guidance as the concepts described are
frequently neither clear nor obvious for newcomers.

It's also redundant, as if it were obvious we wouldn't
be putting it in the documentation.

### Switch validation example away from surname length
This change removes the split of "first name" and
"last name" with just a "name" field, and adds a
"bio" field to use as an example for length
validation.

There's two main reasons for this change:

1. The idea of a neat first name and last name
   is not as universal as we might think, and the
   benefit gained from having separate fields is
   small against the cost of confusion and annoyance.
2. There's no practical reason for putting a length
   limit on a name field, especially one shorter
   than the database field it's going into.  It's
   not a great experience for those of us with
   long surnames.

These sorts of cultural assumptions are not
implemented with malice in mind, just habit,
but they provide little benefit to us as programmers
or to our products, and often only serve to make
those from other cultures feel unwelcome.

We should wherever possible avoid spreading these
antipatterns to other developers.

There's some more discussion on name fields here:
https://www.gov.uk/service-manual/user-centred-design/resources/patterns/names.html